### PR TITLE
Allow admin and users manage withdrawal

### DIFF
--- a/functions/controllers/investmentController.js
+++ b/functions/controllers/investmentController.js
@@ -45,6 +45,7 @@ const getInvestment = async (req, res) => {
       investmentId
     } = req.params;
     const investmentDoc = await db.collection('investments').doc(investmentId).get();
+    if (!investmentDoc.exists) return (0, _response.errorResponse)(res, 500, 'error', _messages.default.unauthorized);
     const investment = investmentDoc.data();
     if (investment.userId != user.uid) return (0, _response.errorResponse)(res, 500, 'error', _messages.default.unauthorized);
     return (0, _response.default)(res, 200, 'success', {

--- a/functions/controllers/withdrawalController.js
+++ b/functions/controllers/withdrawalController.js
@@ -1,0 +1,167 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _firebaseAdmin = _interopRequireDefault(require("../config/firebaseAdmin"));
+
+var _response = _interopRequireWildcard(require("../utils/response"));
+
+var _messages = _interopRequireDefault(require("../utils/messages"));
+
+function _getRequireWildcardCache() { if (typeof WeakMap !== "function") return null; var cache = new WeakMap(); _getRequireWildcardCache = function () { return cache; }; return cache; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } if (obj === null || typeof obj !== "object" && typeof obj !== "function") { return { default: obj }; } var cache = _getRequireWildcardCache(); if (cache && cache.has(obj)) { return cache.get(obj); } var newObj = {}; var hasPropertyDescriptor = Object.defineProperty && Object.getOwnPropertyDescriptor; for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) { var desc = hasPropertyDescriptor ? Object.getOwnPropertyDescriptor(obj, key) : null; if (desc && (desc.get || desc.set)) { Object.defineProperty(newObj, key, desc); } else { newObj[key] = obj[key]; } } } newObj.default = obj; if (cache) { cache.set(obj, newObj); } return newObj; }
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const {
+  db
+} = _firebaseAdmin.default;
+
+const getWithdrawals = async (req, res) => {
+  try {
+    let user = req.user;
+    const withdrawalDoc = await db.collection('withdrawals').where('userId', '==', user.uid).get();
+    const withdrawals = [];
+    withdrawalDoc.forEach(doc => withdrawals.push({
+      id: doc.id,
+      ...doc.data()
+    }));
+    return (0, _response.default)(res, 200, 'success', {
+      withdrawals
+    });
+  } catch (error) {
+    return (0, _response.errorResponse)(res, 500, 'error', error.message);
+  }
+};
+
+const getWithdrawal = async (req, res) => {
+  try {
+    const user = req.user;
+    const {
+      withdrawalId
+    } = req.params;
+    const withdrawalDoc = await db.collection('withdrawals').doc(withdrawalId).get();
+    if (!withdrawalDoc.exists) return (0, _response.errorResponse)(res, 500, 'error', _messages.default.unauthorized);
+    const withdrawal = withdrawalDoc.data();
+    if (withdrawal.userId != user.uid) return (0, _response.errorResponse)(res, 500, 'error', _messages.default.unauthorized);
+    return (0, _response.default)(res, 200, 'success', {
+      withdrawal
+    });
+  } catch (error) {
+    return (0, _response.errorResponse)(res, 500, 'error', error.message);
+  }
+};
+
+const adminGetWithdrawal = async (req, res) => {
+  try {
+    const {
+      withdrawalId
+    } = req.params;
+    const withdrawalDoc = await db.collection('withdrawals').doc(withdrawalId).get();
+    const withdrawal = withdrawalDoc.data();
+    return (0, _response.default)(res, 200, 'success', {
+      id: withdrawalId,
+      ...withdrawal
+    });
+  } catch (error) {
+    return (0, _response.errorResponse)(res, 500, 'error', error.message);
+  }
+};
+
+const getAllWithdrawals = async (req, res) => {
+  try {
+    let user = req.user;
+    const withdrawalDoc = await db.collection('withdrawals').get();
+    const withdrawals = [];
+    withdrawalDoc.forEach(doc => withdrawals.push({
+      id: doc.id,
+      ...doc.data()
+    }));
+    return (0, _response.default)(res, 200, 'success', {
+      withdrawals
+    });
+  } catch (error) {
+    return (0, _response.errorResponse)(res, 500, 'error', error.message);
+  }
+};
+
+const startWithdrawal = async (req, res) => {
+  try {
+    const userId = req.user.uid;
+    const withdrawal = req.withdrawal;
+    const walletRef = await db.collection('wallets').doc(userId);
+    const walletDoc = await walletRef.get();
+    const wallet = walletDoc.data();
+    await walletRef.update({
+      balance: +wallet.balance - +withdrawal.amount,
+      totalWithdraw: +wallet.totalWithdraw + +withdrawal.amount,
+      updatedAt: new Date().toISOString()
+    });
+    await db.collection('withdrawals').add(withdrawal);
+    return (0, _response.default)(res, 201, 'success', {
+      message: _messages.default.withdrawalSuccess
+    });
+  } catch (error) {
+    return (0, _response.errorResponse)(res, 500, 'error', error.message);
+  }
+};
+
+const approveWithdrawal = async (req, res) => {
+  try {
+    const {
+      withdrawalId
+    } = req.params;
+    const withdrawalRef = await db.collection('withdrawals').doc(withdrawalId);
+    const getDoc = await withdrawalRef.get();
+    const withdrawal = getDoc.data(); //check if approved already
+
+    if (withdrawal.status === 'processing' || withdrawal.status === 'settled') return (0, _response.errorResponse)(res, 400, 'error', 'Not allowed, withdrawal already processing');
+    await withdrawalRef.update({
+      status: 'processing',
+      updatedAt: new Date().toISOString()
+    });
+    return (0, _response.default)(res, 201, 'success', {
+      message: _messages.default.withdrawalApprovalSuccess
+    });
+  } catch (error) {
+    return (0, _response.errorResponse)(res, 500, 'error', error.message);
+  }
+};
+
+const settleWithdrawal = async (req, res) => {
+  try {
+    const {
+      withdrawalId
+    } = req.params;
+    const withdrawalRef = await db.collection('withdrawals').doc(withdrawalId);
+    const getDoc = await withdrawalRef.get();
+    const withdrawal = getDoc.data(); //check if settled already
+
+    if (withdrawal.status === 'settled') return (0, _response.errorResponse)(res, 400, 'error', 'Not allowed, withdrawal already settled'); //update investment as settled
+
+    await withdrawalRef.update({
+      status: 'settled',
+      updatedAt: new Date().toISOString()
+    });
+    return (0, _response.default)(res, 201, 'success', {
+      message: _messages.default.settledWithdrawalSuccess
+    });
+  } catch (error) {
+    return (0, _response.errorResponse)(res, 500, 'error', error.message);
+  }
+};
+
+var _default = {
+  getWithdrawals,
+  getWithdrawal,
+  adminGetWithdrawal,
+  startWithdrawal,
+  getAllWithdrawals,
+  approveWithdrawal,
+  settleWithdrawal
+};
+exports.default = _default;

--- a/functions/middlewares/withdrawalMiddleware.js
+++ b/functions/middlewares/withdrawalMiddleware.js
@@ -1,0 +1,64 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.processWithdrawal = void 0;
+
+var _firebaseAdmin = _interopRequireDefault(require("../config/firebaseAdmin"));
+
+var _firebaseClient = _interopRequireDefault(require("../config/firebaseClient"));
+
+var _response = require("../utils/response");
+
+var _messages = _interopRequireDefault(require("../utils/messages"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const {
+  badPlanId,
+  amountOutOfRange
+} = _messages.default;
+const {
+  db
+} = _firebaseAdmin.default;
+/**
+ * @method checkToken
+ * @param {*} req
+ * @param {*} res
+ * @param {*} next
+ * @returns {Object} response object
+ */
+
+const processWithdrawal = async (req, res, next) => {
+  const {
+    amount,
+    bankName,
+    accountName,
+    accountNo
+  } = req.body;
+  const userId = req.user.uid;
+
+  try {
+    const walletRef = await db.collection('wallets').doc(userId);
+    const walletDoc = await walletRef.get();
+    const wallet = walletDoc.data();
+    if (amount > wallet.balance) return (0, _response.errorResponse)(res, 400, 'error', amountOutOfRange); //process withdrawal
+
+    req.withdrawal = {
+      userId: req.user.uid,
+      amount,
+      bankName,
+      accountName,
+      accountName,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    };
+    return next();
+  } catch (error) {
+    return (0, _response.errorResponse)(res, 500, 'error', error.message);
+  }
+};
+
+exports.processWithdrawal = processWithdrawal;

--- a/functions/routes/index.js
+++ b/functions/routes/index.js
@@ -11,6 +11,8 @@ var _walletRoutes = _interopRequireDefault(require("./walletRoutes"));
 
 var _investmentRoutes = _interopRequireDefault(require("./investmentRoutes"));
 
+var _withdrawalRoutes = _interopRequireDefault(require("./withdrawalRoutes"));
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 const routes = router => {
@@ -20,6 +22,7 @@ const routes = router => {
   (0, _authRoutes.default)(router);
   (0, _walletRoutes.default)(router);
   (0, _investmentRoutes.default)(router);
+  (0, _withdrawalRoutes.default)(router);
 };
 
 var _default = routes;

--- a/functions/routes/withdrawalRoutes.js
+++ b/functions/routes/withdrawalRoutes.js
@@ -1,0 +1,42 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _withdrawalController = _interopRequireDefault(require("../controllers/withdrawalController"));
+
+var _validator = _interopRequireDefault(require("../middlewares/validator"));
+
+var _userMiddlewares = require("../middlewares/userMiddlewares");
+
+var _authorizer = _interopRequireDefault(require("../middlewares/authorizer"));
+
+var _withdrawalMiddleware = require("../middlewares/withdrawalMiddleware");
+
+var _withdrawalSchema = require("../validation/withdrawalSchema");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const {
+  getWithdrawals,
+  getAllWithdrawals,
+  getWithdrawal,
+  adminGetWithdrawal,
+  startWithdrawal,
+  approveWithdrawal,
+  settleWithdrawal
+} = _withdrawalController.default;
+
+const withdrawal = router => {
+  router.route('/withdrawals').get(_userMiddlewares.checkToken, getWithdrawals).post(_userMiddlewares.checkToken, (0, _validator.default)(_withdrawalSchema.requestWithdrawalSchema), _withdrawalMiddleware.processWithdrawal, startWithdrawal);
+  router.route('/withdrawals/:withdrawalId').get(_userMiddlewares.checkToken, (0, _validator.default)(_withdrawalSchema.withdrawalSchema), getWithdrawal);
+  router.route('/admin/withdrawals').get(_userMiddlewares.checkToken, (0, _authorizer.default)('admin'), getAllWithdrawals);
+  router.route('/admin/withdrawals/:withdrawalId').get(_userMiddlewares.checkToken, (0, _authorizer.default)('admin'), (0, _validator.default)(_withdrawalSchema.withdrawalSchema), adminGetWithdrawal);
+  router.route('/admin/withdrawals/:withdrawalId').post(_userMiddlewares.checkToken, (0, _authorizer.default)('admin'), (0, _validator.default)(_withdrawalSchema.withdrawalSchema), approveWithdrawal);
+  router.route('/admin/withdrawals/:withdrawalId/settle').post(_userMiddlewares.checkToken, (0, _authorizer.default)('admin'), (0, _validator.default)(_withdrawalSchema.withdrawalSchema), settleWithdrawal);
+};
+
+var _default = withdrawal;
+exports.default = _default;

--- a/functions/utils/messages.js
+++ b/functions/utils/messages.js
@@ -27,8 +27,11 @@ const messages = {
   amountOutOfRange: 'The selected amount is out of range',
   makeAdminSuccess: 'Successful, user is now an admin',
   investmentSuccess: 'Successful, investment added',
+  withdrawalSuccess: 'Successful, withdrawal added',
   approvalSuccess: 'Successful, investment approved',
+  withdrawalApprovalSuccess: 'Successful, withdrawal approved',
   settledSuccess: 'Successful, investment settled',
+  settledWithdrawalSuccess: 'Successful, withdrawal settled',
   notAllowed: 'Action not allowed, not yet time'
 };
 var _default = messages;

--- a/functions/validation/withdrawalSchema.js
+++ b/functions/validation/withdrawalSchema.js
@@ -1,0 +1,27 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.requestWithdrawalSchema = exports.withdrawalSchema = void 0;
+
+var _joi = _interopRequireDefault(require("@hapi/joi"));
+
+var _JoiValidator = _interopRequireDefault(require("./JoiValidator"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const withdrawalSchema = _joi.default.object({
+  withdrawalId: _JoiValidator.default.validateString().required()
+});
+
+exports.withdrawalSchema = withdrawalSchema;
+
+const requestWithdrawalSchema = _joi.default.object({
+  amount: _JoiValidator.default.validateNumber().required(),
+  bankName: _JoiValidator.default.validateString().required(),
+  accountName: _JoiValidator.default.validateString().required(),
+  accountNo: _JoiValidator.default.validateString().required()
+});
+
+exports.requestWithdrawalSchema = requestWithdrawalSchema;

--- a/src/controllers/investmentController.js
+++ b/src/controllers/investmentController.js
@@ -22,6 +22,7 @@ const getInvestment = async (req, res) => {
     const { investmentId } = req.params;
 
     const investmentDoc = await db.collection('investments').doc(investmentId).get();
+    if(!investmentDoc.exists) return errorResponse(res, 500, 'error', messages.unauthorized);
     const investment = investmentDoc.data();
     if(investment.userId != user.uid) return errorResponse(res, 500, 'error', messages.unauthorized)
     return response(res, 200, 'success', { investment })

--- a/src/controllers/withdrawalController.js
+++ b/src/controllers/withdrawalController.js
@@ -1,0 +1,126 @@
+import firebaseAdmin from '../config/firebaseAdmin';
+import response, { errorResponse } from '../utils/response';
+import messages from '../utils/messages';
+
+const { db } = firebaseAdmin;
+
+const getWithdrawals = async (req, res) => {
+  try {
+    let user = req.user;
+    const withdrawalDoc = await db.collection('withdrawals').where('userId', '==', user.uid).get();
+    const withdrawals = [];
+    withdrawalDoc.forEach(doc => withdrawals.push({id: doc.id, ...doc.data()}))
+    return response(res, 200, 'success', { withdrawals })
+  } catch (error) {
+    return errorResponse(res, 500, 'error', error.message)
+  }
+}
+
+const getWithdrawal = async (req, res) => {
+  try {
+    const user = req.user;
+    const { withdrawalId } = req.params;
+
+    const withdrawalDoc = await db.collection('withdrawals').doc(withdrawalId).get();
+    if(!withdrawalDoc.exists) return errorResponse(res, 500, 'error', messages.unauthorized);
+    const withdrawal = withdrawalDoc.data();
+    if(withdrawal.userId != user.uid) return errorResponse(res, 500, 'error', messages.unauthorized)
+    return response(res, 200, 'success', { withdrawal })
+  } catch (error) {
+    return errorResponse(res, 500, 'error', error.message)
+  }
+}
+
+const adminGetWithdrawal = async (req, res) => {
+  try {
+    const { withdrawalId } = req.params;
+
+    const withdrawalDoc = await db.collection('withdrawals').doc(withdrawalId).get();
+    const withdrawal = withdrawalDoc.data();
+    return response(res, 200, 'success', {id: withdrawalId, ...withdrawal })
+  } catch (error) {
+    return errorResponse(res, 500, 'error', error.message)
+  }
+}
+
+const getAllWithdrawals = async (req, res) => {
+  try {
+    let user = req.user;
+    const withdrawalDoc = await db.collection('withdrawals').get();
+    const withdrawals = [];
+    withdrawalDoc.forEach(doc => withdrawals.push({id: doc.id, ...doc.data()}))
+    return response(res, 200, 'success', { withdrawals })
+  } catch (error) {
+    return errorResponse(res, 500, 'error', error.message)
+  }
+}
+
+const startWithdrawal = async (req, res) => {
+  try {
+    const userId = req.user.uid;
+    const withdrawal = req.withdrawal;
+
+    const walletRef = await db.collection('wallets').doc(userId);
+    const walletDoc = await walletRef.get();
+    const wallet = walletDoc.data();
+    await walletRef.update({
+      balance: +wallet.balance - +withdrawal.amount,
+      totalWithdraw: +wallet.totalWithdraw + +withdrawal.amount,
+      updatedAt: new Date().toISOString(),
+    })
+    await db.collection('withdrawals').add(withdrawal);
+    return response(res, 201, 'success', { message: messages.withdrawalSuccess })
+  } catch (error) {
+    return errorResponse(res, 500, 'error', error.message)
+  }
+}
+
+const approveWithdrawal = async (req, res) => {
+  try {
+    const { withdrawalId } = req.params;
+
+    const withdrawalRef = await db.collection('withdrawals').doc(withdrawalId);
+    const getDoc = await withdrawalRef.get();
+    const withdrawal = getDoc.data();
+
+    //check if approved already
+    if(withdrawal.status === 'processing' || withdrawal.status === 'settled') return errorResponse(res, 400, 'error', 'Not allowed, withdrawal already processing');
+
+    await withdrawalRef.update(
+        { 
+          status: 'processing',
+          updatedAt:  new Date().toISOString()
+        }
+      );
+    return response(res, 201, 'success', { message: messages.withdrawalApprovalSuccess })
+  } catch (error) {
+    return errorResponse(res, 500, 'error', error.message)
+  }
+}
+
+const settleWithdrawal = async (req, res) => {
+  try {
+    const { withdrawalId } = req.params;
+
+    const withdrawalRef = await db.collection('withdrawals').doc(withdrawalId);
+    const getDoc = await withdrawalRef.get();
+    const withdrawal = getDoc.data();
+
+    //check if settled already
+    if(withdrawal.status === 'settled') return errorResponse(res, 400, 'error', 'Not allowed, withdrawal already settled');
+
+    //update investment as settled
+    await withdrawalRef.update(
+        { 
+          status: 'settled',
+          updatedAt:  new Date().toISOString()
+        }
+      );
+    return response(res, 201, 'success', { message: messages.settledWithdrawalSuccess })
+  } catch (error) {
+    return errorResponse(res, 500, 'error', error.message)
+  }
+}
+
+export default { getWithdrawals, getWithdrawal, adminGetWithdrawal,
+  startWithdrawal, getAllWithdrawals, approveWithdrawal, settleWithdrawal };

--- a/src/middlewares/withdrawalMiddleware.js
+++ b/src/middlewares/withdrawalMiddleware.js
@@ -1,0 +1,44 @@
+import firebaseAdmin from '../config/firebaseAdmin';
+import firebaseClient from '../config/firebaseClient';
+import { errorResponse } from '../utils/response';
+import messages from '../utils/messages';
+
+const {
+  badPlanId, amountOutOfRange
+} = messages;
+
+const { db } = firebaseAdmin;
+
+/**
+ * @method checkToken
+ * @param {*} req
+ * @param {*} res
+ * @param {*} next
+ * @returns {Object} response object
+ */
+export const processWithdrawal = async (req, res, next) => {
+  const { amount, bankName, accountName, accountNo } = req.body;
+  const userId = req.user.uid;
+  try {
+    const walletRef = await db.collection('wallets').doc(userId);
+    const walletDoc = await walletRef.get();
+    const wallet = walletDoc.data();
+    if(amount > wallet.balance) return errorResponse(res, 400, 'error', amountOutOfRange);
+
+    //process withdrawal
+    req.withdrawal = {
+      userId: req.user.uid,
+      amount,
+      bankName,
+      accountName,
+      accountName,
+      status: 'pending',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+
+    return next();
+  } catch (error) {
+    return errorResponse(res, 500, 'error', error.message);
+  }
+};

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,6 +1,7 @@
 import auth from './authRoutes';
 import wallet from './walletRoutes';
 import investment from './investmentRoutes';
+import withdrawal from './withdrawalRoutes';
 
 const routes = (router) => {
 
@@ -11,6 +12,7 @@ const routes = (router) => {
   auth(router);
   wallet(router);
   investment(router);
+  withdrawal(router);
 
 }
 

--- a/src/routes/withdrawalRoutes.js
+++ b/src/routes/withdrawalRoutes.js
@@ -1,0 +1,34 @@
+import withdrawalController from "../controllers/withdrawalController";
+import validate from '../middlewares/validator';
+import { checkToken } from '../middlewares/userMiddlewares';
+import authorize from '../middlewares/authorizer';
+import { processWithdrawal } from '../middlewares/withdrawalMiddleware';
+import {
+  withdrawalSchema, requestWithdrawalSchema
+} from '../validation/withdrawalSchema';
+
+const { getWithdrawals, getAllWithdrawals, getWithdrawal, adminGetWithdrawal,
+  startWithdrawal, approveWithdrawal, settleWithdrawal } = withdrawalController;
+
+const withdrawal = (router) => {
+  router.route('/withdrawals')
+    .get(checkToken, getWithdrawals)
+    .post(checkToken, validate(requestWithdrawalSchema), processWithdrawal, startWithdrawal);
+
+  router.route('/withdrawals/:withdrawalId')
+    .get(checkToken, validate(withdrawalSchema), getWithdrawal);
+  
+  router.route('/admin/withdrawals')
+    .get(checkToken, authorize('admin'), getAllWithdrawals);
+  
+  router.route('/admin/withdrawals/:withdrawalId')
+    .get(checkToken, authorize('admin'), validate(withdrawalSchema), adminGetWithdrawal);
+
+  router.route('/admin/withdrawals/:withdrawalId')
+    .post(checkToken, authorize('admin'), validate(withdrawalSchema), approveWithdrawal);
+  
+  router.route('/admin/withdrawals/:withdrawalId/settle')
+    .post(checkToken, authorize('admin'), validate(withdrawalSchema), settleWithdrawal);
+}
+
+export default withdrawal;

--- a/src/utils/messages.js
+++ b/src/utils/messages.js
@@ -21,8 +21,11 @@ const messages = {
   amountOutOfRange: 'The selected amount is out of range',
   makeAdminSuccess: 'Successful, user is now an admin',
   investmentSuccess: 'Successful, investment added',
+  withdrawalSuccess: 'Successful, withdrawal added',
   approvalSuccess: 'Successful, investment approved',
+  withdrawalApprovalSuccess: 'Successful, withdrawal approved',
   settledSuccess: 'Successful, investment settled',
+  settledWithdrawalSuccess: 'Successful, withdrawal settled',
   notAllowed: 'Action not allowed, not yet time',
 };
 

--- a/src/validation/withdrawalSchema.js
+++ b/src/validation/withdrawalSchema.js
@@ -1,0 +1,17 @@
+import Joi from '@hapi/joi';
+import JoiValidator from './JoiValidator';
+
+const withdrawalSchema = Joi.object({
+  withdrawalId: JoiValidator.validateString().required(),
+});
+
+const requestWithdrawalSchema = Joi.object({
+  amount: JoiValidator.validateNumber().required(),
+  bankName: JoiValidator.validateString().required(),
+  accountName: JoiValidator.validateString().required(),
+  accountNo: JoiValidator.validateString().required(),
+});
+
+export {
+  withdrawalSchema, requestWithdrawalSchema
+};


### PR DESCRIPTION

#### What does this PR do?
This PR integrates withdrawal features for admin and users
#### Description of Task to be completed?
- create withdrawal routes
- create withdrawal controllers
- create middlewares
- create validation schemas
#### How should this be manually tested?
- cloned repo
- install dependencies using npm install
- npm run serve
- firebase serve
- using postman GET http://localhost:5000/cryptofox/us-central1/api/v1/withdrawals
using postman GET http://localhost:5000/cryptofox/us-central1/api/v1/withdrawals/withdrawalId
using postman POST http://localhost:5000/cryptofox/us-central1/api/v1/withdrawals
using postman GET http://localhost:5000/cryptofox/us-central1/api/v1/admin/withdrawals/withdrawalId
using postman GET http://localhost:5000/cryptofox/us-central1/api/v1/withdrawals
using postman POST http://localhost:5000/cryptofox/us-central1/api/v1/admin/withdrawals/withdrawalId
using postman POST http://localhost:5000/cryptofox/us-central1/api/v1/admin/withdrawals/withdrawalId/settle
[Finishes]